### PR TITLE
docs: Fixed grammatical issue in the "contribute to Optimism" phrasing

### DIFF
--- a/pages/introduction.mdx
+++ b/pages/introduction.mdx
@@ -12,7 +12,7 @@ The Optimism Collective's vision is enabling this by creating a platform where w
 Because we are builders, and we know that composability is a good thing, so rolling our own code would have been counterproductive.
 OP Stack is built on a modular architecture, so we can contribute with solutions and innovations to existing problems instead of building something new.
 
-We are committed to contribute to Optimism in a positive manner for the growth of the whole ecosystem.
+We are committed to contribute to the Optimism in a positive manner for the growth of the whole ecosystem.
 
 ### We care about Decentralization
 


### PR DESCRIPTION
I’ve corrected a small grammatical issue in the text where the phrase "contribute to Optimism" was used. The proper structure should be "contribute to the Optimism" to ensure grammatical correctness in English. This small change improves the overall clarity and fluency of the content.

Although this may seem like a minor edit, it’s important for maintaining professionalism and accuracy in our communications. Small grammatical errors can affect the credibility of the project, so it’s essential to ensure that all phrasing is correct and polished.