### PR TITLE
Fix broken link to design philosophy page

### DIFF
--- a/pages/faq.mdx
+++ b/pages/faq.mdx
@@ -31,4 +31,4 @@ This approach future-proofs our platform while ensuring security and efficiency.
 
 We adopt the OP Stack's design principles because, as builders, we know they work and strongly align with our values.
 
-You can find the Optimism Design Philosophy [here (opens in a new tab)](https://community.optimism.io/research/research-overview).
+You can find the Optimism Design Philosophy [here (opens in a new tab)](https://docs.optimism.io/stack/design-principles).


### PR DESCRIPTION
The previous link to the Optimism design philosophy (https://community.optimism.io/docs/protocol/1-design-philosophy/) is no longer functional and results in a 404 error.
This PR replaces it with an updated and relevant page: https://community.optimism.io/research/research-overview, which outlines Optimism’s experimental approach and governance philosophy.