### PR TITLE
Added dRPC as RPC provider | Update to rpc-node-providers.mdx

### DIFF
--- a/pages/integrations/rpc-node-providers.mdx
+++ b/pages/integrations/rpc-node-providers.mdx
@@ -18,6 +18,14 @@ QuickNode provides RPC endpoints for Superseed, along with websocket support and
 - Mainnet
 - Sepolia Testnet
 
+## [dRPC](https://drpc.org/)
+
+dRPC provides high-performance Superseed RPC endpoints from globally distributed nodes, including websocket support.
+
+### Supported Networks
+
+- [Mainnet](https://drpc.org/chainlist/superseed)
+
 ## Superseed Public RPC
 
 **Endpoints:**


### PR DESCRIPTION
Hey, we at dRPC just added support for Superseed Mainnet and Testnet is coming later. 