### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/content/integrations/faucets.mdx
+++ b/content/integrations/faucets.mdx
@@ -46,3 +46,15 @@ The [Ethereum Sepolia Faucet](https://www.ethereum-ecosystem.com/faucets/ethereu
 <Callout type="info" emoji="ℹ️">
   Github authentication required.
 </Callout>
+
+---
+
+## [ethfaucet.com](https://ethfaucet.com?utm_source=superseed_docs&utm_medium=docs)
+
+[ethfaucet.com](https://ethfaucet.com?utm_source=superseed_docs&utm_medium=docs) provides developers with 0.1 Superseed Sepolia ETH for free, claimable once every 24 hours.
+
+Operated and maintained by [BringID](https://www.bringid.org?utm_source=superseed_docs&utm_medium=docs).
+
+<Callout type="info" emoji="ℹ️">
+  Supports both addresses with transaction history and new addresses via Proof of Humanity verification.
+</Callout>


### PR DESCRIPTION
## Description

Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Superseed Sepolia ETH for free, claimable once every 24 hours.

#### Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.

## Related Issues

—

## Checklist

- [ +] I have tested the changes
- [ +] I have updated the documentation
- [ +] I have added necessary tests