### PR TITLE
Add Envio to Data Providers

### DIFF
--- a/content/chain/integrations/data-providers.mdx
+++ b/content/chain/integrations/data-providers.mdx
@@ -8,7 +8,7 @@ Envio is a high-performance indexing framework that turns smart contract events 
 
 2. **HyperSync**: a high-performance data engine that acts as the default data source for supported chains. The Superseed HyperSync endpoint is `https://superseed.hypersync.xyz`. Envio also offers HyperRPC, an extremely fast read-only RPC.
 
-Deploy and scale your indexer on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups, or self-host. For detailed documentation and quick start guides, you can explore the [HyperIndex overview](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=superseed&utm_medium=partner-docs) and [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=superseed&utm_medium=partner-docs) resources.
+Deploy and scale your indexer on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups, or self-host. For detailed documentation and quick start guides, you can explore the [HyperIndex overview](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=superseed&utm_medium=partner-docs) and [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=superseed&utm_medium=partner-docs) resources. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=superseed&utm_medium=partner-docs).
 
 ### Supported Networks
 

--- a/content/chain/integrations/data-providers.mdx
+++ b/content/chain/integrations/data-providers.mdx
@@ -2,7 +2,7 @@
 
 ## Envio
 
-Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, and Superseed is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
+Envio is the data layer for blockchain apps. It gives Superseed developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Superseed is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
 
 1. **HyperIndex**: a full-featured indexing framework that takes you from smart contract events to a queryable GraphQL API. Auto-generate an indexer from any verified contract with `pnpx envio init`, write event handlers in TypeScript, JavaScript, or ReScript, and get reorg support, real-time and historical data, historical backfills at 30,000+ events per second, and multichain data aggregation across EVM and non-EVM networks.
 

--- a/content/chain/integrations/data-providers.mdx
+++ b/content/chain/integrations/data-providers.mdx
@@ -1,5 +1,21 @@
 # Data Providers
 
+## Envio
+
+Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, and Superseed is served by HyperSync, Envio's high-performance data engine that is up to 2000x faster than traditional RPC.
+
+1. **HyperIndex**: a full-featured indexing framework that takes you from smart contract events to a queryable GraphQL API. Auto-generate an indexer from any verified contract with `pnpx envio init`, write event handlers in TypeScript, JavaScript, or ReScript, and get reorg support, real-time and historical data, historical backfills at 30,000+ events per second, and multichain data aggregation across EVM and non-EVM networks.
+
+2. **HyperSync**: a high-performance data engine that acts as the default data source for supported chains. The Superseed HyperSync endpoint is `https://superseed.hypersync.xyz`. Envio also offers HyperRPC, an extremely fast read-only RPC.
+
+Deploy and scale your indexer on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups, or self-host. For detailed documentation and quick start guides, you can explore the [HyperIndex overview](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=superseed&utm_medium=partner-docs) and [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=superseed&utm_medium=partner-docs) resources.
+
+### Supported Networks
+
+- Mainnet
+
+---
+
 ## Goldsky
 
 Goldsky serves as a go-to data indexer for web3 builders, offering two core self-serve products: Subgraphs and Mirror. 

--- a/content/chain/integrations/data-providers.mdx
+++ b/content/chain/integrations/data-providers.mdx
@@ -8,7 +8,7 @@ Envio is the data layer for blockchain apps. It gives Superseed developers the f
 
 2. **HyperSync**: a high-performance data engine that acts as the default data source for supported chains. The Superseed HyperSync endpoint is `https://superseed.hypersync.xyz`. Envio also offers HyperRPC, an extremely fast read-only RPC.
 
-Deploy and scale your indexer on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups, or self-host. For detailed documentation and quick start guides, you can explore the [HyperIndex overview](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=superseed&utm_medium=partner-docs) and [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=superseed&utm_medium=partner-docs) resources. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=superseed&utm_medium=partner-docs).
+Deploy and scale your indexer on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups, or self-host. For detailed documentation and quick start guides, you can explore the [HyperIndex overview](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=superseed&utm_medium=partner-docs) and [quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=superseed&utm_medium=partner-docs) resources.
 
 ### Supported Networks
 


### PR DESCRIPTION
This adds Envio to the Data Providers page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. HyperIndex natively supports indexing any EVM chain, and Superseed is served by HyperSync, Envio's high-performance data engine.

The entry mirrors the existing Goldsky entry format, including a Supported Networks section and the Superseed HyperSync endpoint.

Links:
- Website: https://envio.dev/
- Docs: https://docs.envio.dev/